### PR TITLE
feat: add configurable rich presence button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ venv/
 *.tar
 *.rar
 *.7z
+# ユーザー固有の設定ファイルを無視
+config.ini

--- a/MCS-DiscordRPC.py
+++ b/MCS-DiscordRPC.py
@@ -17,6 +17,8 @@ config.read('config.ini')
 TOKEN = config.get('DEFAULT', 'token')
 # Minecraftサーバーのアドレス（config.iniから取得）
 SERVER_ADDRESS = config.get('DEFAULT', 'server_address')
+# Discordリッチプレゼンスに表示するボタンのリンク（空文字の場合はボタン非表示）
+BUTTON_LINK = config.get('DEFAULT', 'ButtonLink', fallback='')
 
 # Discordクライアントの生成（特別なIntentsは不要なのでデフォルトを使用）
 bot = discord.Client(intents=discord.Intents.default())  # Discordに接続するためのクライアント
@@ -70,11 +72,15 @@ async def update_presence():
             sample = status.players.sample or []  # サンプルからプレイヤー情報を取得
             player_names = ', '.join(p.name for p in sample) if sample else 'プレイヤーはいません'
 
+        # ボタン情報のリストを作成（リンクが設定されている場合のみボタンを表示）
+        buttons = [{"label": "Join Server", "url": BUTTON_LINK}] if BUTTON_LINK else None
+
         # Discordのリッチプレゼンス情報を作成
         activity = discord.Activity(
             type=discord.ActivityType.playing,                   # プレイ中のアクティビティとして表示
             name=f'{player_count}/{max_players} players online', # 名前欄にプレイヤー人数を表示
-            state=player_names                                   # 状態欄にプレイヤー名を表示
+            state=player_names,                                  # 状態欄にプレイヤー名を表示
+            buttons=buttons                                      # ボタン情報を設定（Noneの場合は非表示）
         )
         # プレゼンスを更新
         await bot.change_presence(activity=activity)  # 作成したプレゼンスをDiscordに送信

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ## 使い方
 1. `example_config.ini`を`config.ini`にコピーし、DiscordのボットトークンとMinecraftサーバーのアドレスを設定してください。
+   `ButtonLink`にURLを設定するとプレゼンスにボタンが表示されます。
 2. `setup.sh`または`setup.bat`を実行し、必要なライブラリをインストールしてください。
 3. 仮想環境を有効化し、`run.bat`（Windows）または`python MCS-DiscordRPC.py`を実行してボットを起動します。
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -3,3 +3,5 @@
 TOKEN = "Your Discord Bot Token Here"
 # Minecraftサーバーのアドレス (例: example.com:25565)
 SERVER_ADDRESS = localhost:25565
+# Discordリッチプレゼンスに表示するボタンのリンク（未設定の場合はボタン非表示）
+ButtonLink =


### PR DESCRIPTION
## Summary
- add optional button to Discord Rich Presence when `ButtonLink` is set
- document new `ButtonLink` config option
- ignore user-specific `config.ini`

## Testing
- `python -m py_compile MCS-DiscordRPC.py`


------
https://chatgpt.com/codex/tasks/task_e_689c4a1d8b88832491119cab14dbb306