### PR TITLE
設定読み込みの柔軟化と更新間隔設定への対応

### DIFF
--- a/MCS-DiscordRPC.py
+++ b/MCS-DiscordRPC.py
@@ -29,12 +29,106 @@ for encoding in encoding_candidates:
 # どのエンコーディングでも読み込めなかった場合はエラーを投げて終了する
 if not config_loaded:
     raise UnicodeDecodeError('config.ini', b'', 0, 0, '設定ファイルを読み込めませんでした。エンコーディングをUTF-8に変更してください。')
-# Discordのボットトークン（config.iniから取得）
-TOKEN = config.get('DEFAULT', 'token')
-# Minecraftサーバーのアドレス（config.iniから取得）
-SERVER_ADDRESS = config.get('DEFAULT', 'server_address')
+# 設定値を取得する際に利用するセクション候補のリスト（`None`はDEFAULTセクションを表す）
+section_candidates = [None, 'discord', 'server', 'commands', 'logging']
+
+
+# _resolve_option関数
+#   役割  : 複数セクションを順番に探索して設定値を取得する
+#   呼び出し: モジュール初期化時にトークンやアドレス取得で利用される
+#   引数  : option_name(str) 取得したいオプション名
+#           fallback(str | None) オプションが見つからない場合に返す既定値（省略可）
+#           aliases(tuple[str, ...]) 同義語として探索する追加のオプション名（任意）
+#   戻り値: str | None 見つかった設定値またはフォールバック値
+def _resolve_option(option_name, *, fallback=None, aliases=()):
+    # 探索するオプション名の候補を準備する（先頭ほど優先される）
+    option_names = (option_name, *aliases)
+    # 各セクションを順番に調べる
+    for section in section_candidates:
+        # Noneが指定された場合はDEFAULTセクションを参照する
+        target_section = configparser.DEFAULTSECT if section is None else section
+        # セクションが存在し、かつオプションが定義されているか確認する
+        if config.has_section(target_section) or target_section == configparser.DEFAULTSECT:
+            for name in option_names:
+                # オプション名の候補を順に試し、見つかった時点で値を返す
+                if config.has_option(target_section, name):
+                    return config.get(target_section, name)
+    # いずれのセクションにも存在しなかった場合はフォールバック値を返す
+    return fallback
+
+
+# _resolve_int_option関数
+#   役割  : 数値設定を取得し、整数型に変換して返す
+#   呼び出し: プレゼンス更新間隔の設定値取得時に使用される
+#   引数  : option_name(str) 取得したいオプション名
+#           fallback(int | None) オプションが見つからない場合に返す既定値
+#           aliases(tuple[str, ...]) 同義語として探索する追加のオプション名（任意）
+#   戻り値: int | None 見つかった設定値を整数化したもの、またはフォールバック値
+def _resolve_int_option(option_name, *, fallback=None, aliases=()):
+    # 文字列として設定値を取得する
+    value = _resolve_option(option_name, fallback=None, aliases=aliases)
+    # 値が取得できなかった場合はフォールバックを返す
+    if value is None:
+        return fallback
+    try:
+        # 整数に変換して返す
+        return int(value)
+    except ValueError:
+        # 数値以外が設定されていた場合はフォールバックを返す
+        return fallback
+
+
+# _resolve_server_address関数
+#   役割  : Minecraftサーバーへ接続するためのアドレス文字列を決定する
+#   呼び出し: モジュール初期化時に一度だけ呼ばれる
+#   引数  : なし
+#   戻り値: str 接続に使用するアドレス（例: "example.com:25565"）
+def _resolve_server_address():
+    # server_addressの明示的な指定を優先して取得する
+    explicit_address = _resolve_option('server_address')
+    if explicit_address:
+        return explicit_address
+
+    # ホスト名とポート番号の候補を取得する（存在しない場合はNoneが返る）
+    host = (
+        _resolve_option('server_host')
+        or _resolve_option('host')
+        or _resolve_option('rcon_host')
+    )
+    port = (
+        _resolve_option('server_port')
+        or _resolve_option('port')
+        or _resolve_option('rcon_port')
+    )
+
+    # ホスト名が得られた場合はポートの有無で文字列を組み立てる
+    if host:
+        # ポート番号が設定されている場合は「host:port」の形式で返す
+        if port:
+            return f'{host}:{port}'
+        # ポート未指定の場合はホスト名のみで返す（mcstatusは25565を既定値として使用する）
+        return host
+
+    # 必要な設定が見つからない場合はユーザーに設定不足を知らせるため例外を送出する
+    raise configparser.NoOptionError('server_address', 'config.ini 内のDEFAULT/discord/serverいずれかのセクション')
+
+
+# Discordのボットトークン（config.iniから取得、見つからない場合は明示的な例外を出す）
+TOKEN = _resolve_option('token')
+if not TOKEN:
+    raise configparser.NoOptionError('token', 'config.ini 内のDEFAULT/discordいずれかのセクション')
+
+# Minecraftサーバーのアドレス（複数の候補から決定する）
+SERVER_ADDRESS = _resolve_server_address()
+
 # Discordリッチプレゼンスに表示するボタンのリンク（空文字の場合はボタン非表示）
-BUTTON_LINK = config.get('DEFAULT', 'ButtonLink', fallback='')
+BUTTON_LINK = _resolve_option('button_link', fallback='', aliases=('buttonlink', 'button-link'))
+
+# ステータスを更新する間隔（秒）
+STATUS_INTERVAL = _resolve_int_option('status_interval', fallback=30)
+if STATUS_INTERVAL is None or STATUS_INTERVAL <= 0:
+    # 無効な値が設定されていた場合は既定値の30秒に戻す
+    STATUS_INTERVAL = 30
 
 # Discordクライアントの生成（特別なIntentsは不要なのでデフォルトを使用）
 bot = discord.Client(intents=discord.Intents.default())  # Discordに接続するためのクライアント
@@ -62,7 +156,8 @@ tmp_player_count = -1
 #   呼び出し: tasks.loopデコレータにより30秒ごとに呼び出される
 #   引数  : なし
 #   戻り値: なし
-@tasks.loop(seconds=30)
+# ループの実行間隔に設定値を使用する
+@tasks.loop(seconds=STATUS_INTERVAL)
 async def update_presence():
     # グローバル変数の参照を宣言
     global isAwake, tmp_player_count  # 状態管理の変数をグローバルとして使用


### PR DESCRIPTION
## 概要
- 設定探索対象のセクションを拡張し、オプション名の表記ゆれに対応するヘルパーを追加しました
- 数値設定を取得する関数を導入し、STATUS_INTERVALからプレゼンス更新間隔を読み込むようにしました
- ボタンリンク設定でBUTTON_LINKなど複数のキー名を解釈できるようにしました

## テスト
- python -m py_compile MCS-DiscordRPC.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691207c777d88324b54fd6642e2df390)