### PR TITLE
StatusUpdaterCogでasyncio.create_taskを用いる対応

### DIFF
--- a/bot/cogs/status_updater.py
+++ b/bot/cogs/status_updater.py
@@ -51,8 +51,8 @@ class StatusUpdaterCog(commands.Cog):
     # 引数: なし
     # 戻り値: なし
     async def cog_load(self) -> None:
-        # Botの起動完了を待って初期化を行うタスクを生成する処理
-        self._startup_task = self._bot.loop.create_task(self._initialize_after_ready())
+        # Botの起動完了を待って初期化を行うタスクを生成する処理（asyncio.create_taskを使用してループ非公開化に対応）
+        self._startup_task = asyncio.create_task(self._initialize_after_ready())
 
     # このメソッドはCogがアンロードされる際に呼び出され、監視タスクを停止する
     # 呼び出し元: discord.pyのCogライフサイクル
@@ -83,8 +83,8 @@ class StatusUpdaterCog(commands.Cog):
         await self._bot.wait_until_ready()
         # 状況メッセージの存在を確保する処理
         await self._manager.ensure_message()
-        # 状況監視ループを開始する処理
-        self._task = self._bot.loop.create_task(self._run_loop())
+        # 状況監視ループを開始する処理（asyncio.create_taskでイベントループ取得を抽象化）
+        self._task = asyncio.create_task(self._run_loop())
         # 初期化タスクの参照を解放する処理
         self._startup_task = None
 


### PR DESCRIPTION
## 概要
- StatusUpdaterCogの起動時初期化タスクおよび監視タスク生成でasyncio.create_taskを使用するように修正し、discord.py 2.xでのloop属性非公開化に対応しました。

## テスト
- 未実施（ローカル環境未構築のため）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913516ca15c832489bd295ac8cbc438)