### PR TITLE
非同期ログキューでイベントループの停止を防止

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -6,8 +6,12 @@ Discord Botを初期化して各Cogを登録するエントリポイント。
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
+from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
+from queue import SimpleQueue
+from typing import Optional
 
 import discord
 from discord.ext import commands
@@ -21,6 +25,40 @@ from .utils.error_reporter import ErrorReporter
 from .utils.console_status import console_status_display
 
 
+# この変数は非同期ログ出力を担当するQueueListenerを保持する
+_LOGGING_LISTENER: Optional[QueueListener] = None
+
+
+# この関数はイベントループをブロックしないログ設定を適用する
+# 呼び出し元: main 関数の設定読み込み後
+# 引数: level_name は設定ファイルで指定されたログレベル名
+# 戻り値: なし
+def _setup_async_logging(level_name: str) -> None:
+    # グローバルに保持しているQueueListenerへアクセスする処理
+    global _LOGGING_LISTENER
+    # ログレベル名から数値レベルへ変換する処理（無効な値はINFOへフォールバック）
+    level_value = getattr(logging, level_name.upper(), logging.INFO)
+    # ログレコードをスレッド間で受け渡すキューを生成する処理
+    record_queue: "SimpleQueue[logging.LogRecord]" = SimpleQueue()
+    # 実際に標準エラーへ書き出すStreamHandlerを構築する処理
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(level_value)
+    # 既存のハンドラー構成をクリアしてQueueHandlerのみを登録する処理
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    queue_handler = QueueHandler(record_queue)
+    queue_handler.setLevel(level_value)
+    root_logger.addHandler(queue_handler)
+    root_logger.setLevel(level_value)
+    # 新たにQueueListenerを起動してログレコードを非同期に処理する処理
+    listener = QueueListener(record_queue, stream_handler)
+    listener.start()
+    # 生成したQueueListenerをグローバル変数へ保持する処理
+    _LOGGING_LISTENER = listener
+    # プロセス終了時にQueueListenerを停止させる後処理を登録する処理
+    atexit.register(listener.stop)
+
+
 # この関数はBotを起動するための非同期エントリポイント
 # 呼び出し元: スクリプトのmainセクション
 # 引数: なし
@@ -31,8 +69,8 @@ async def main() -> None:
     # 設定ファイルを読み込む処理
     loader = ConfigLoader()
     config = loader.load()
-    # ログ設定を適用する処理
-    logging.basicConfig(level=getattr(logging, config.logging.level.upper(), logging.INFO))
+    # ログ設定を適用する処理（非同期化でイベントループのブロッキングを回避）
+    _setup_async_logging(config.logging.level)
     # Discord Intentsを構築する処理
     intents = discord.Intents.default()
     intents.message_content = True


### PR DESCRIPTION
## 概要
- QueueHandlerとQueueListenerを用いてログ出力を非同期化し、Discordのイベントループが長時間ブロックされないようにしました
- 設定読み込み後に非同期ログ設定を適用するユーティリティ関数を追加しました

## テスト
- python -m compileall bot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913662610948324975dad360b7bcb8f)