### PR TITLE
サーバー状況チャンネルの履歴整理と最終操作表示の改善

### DIFF
--- a/bot/cogs/server_commands.py
+++ b/bot/cogs/server_commands.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Awaitable, Callable, Optional, Tuple
 
 import discord
@@ -104,6 +105,8 @@ class ServerCommandsCog(commands.Cog):
         if not self._has_permission(ctx):
             await ctx.reply("このコマンドを実行する権限がありません", mention_author=False)
             return
+        # 新たなコマンド実行前に旧メッセージを整理する処理
+        await self._manager.cleanup_command_messages(preserve_ids=(ctx.message.id,))
         # 進捗表示用のメッセージを送信する処理
         response = await ctx.reply("サーバー起動処理を準備しています…", mention_author=False)
         # 実際のサーバー操作を共通関数に委譲する処理
@@ -128,11 +131,22 @@ class ServerCommandsCog(commands.Cog):
         if not self._has_permission(ctx):
             await ctx.reply("このコマンドを実行する権限がありません", mention_author=False)
             return
+        # 新たなコマンド実行前に旧メッセージを整理する処理
+        await self._manager.cleanup_command_messages(preserve_ids=(ctx.message.id,))
         # 状況確認を案内する初期メッセージを送信する処理
         response = await ctx.reply("プレイヤー状況を確認しています…", mention_author=False)
         # 状況確認と確認ダイアログを実行する処理
         if not await self._confirm_if_players(ctx):
             await response.edit(content="操作をキャンセルしました")
+            # 操作者がキャンセルした場合も履歴へ残す処理
+            # ステータス履歴に記録するために実行者名を取得する処理
+            actor_label = getattr(ctx.author, "display_name", str(ctx.author))
+            self._manager.register_operation(
+                actor_name=actor_label,
+                summary="停止操作をキャンセルしました",
+                success=False,
+                occurred_at=datetime.now(timezone.utc),
+            )
             return
         # 実際のサーバー操作を共通関数に委譲する処理
         await self._execute_action(
@@ -156,11 +170,22 @@ class ServerCommandsCog(commands.Cog):
         if not self._has_permission(ctx):
             await ctx.reply("このコマンドを実行する権限がありません", mention_author=False)
             return
+        # 新たなコマンド実行前に旧メッセージを整理する処理
+        await self._manager.cleanup_command_messages(preserve_ids=(ctx.message.id,))
         # 確認フローの案内メッセージを送信する処理
         response = await ctx.reply("プレイヤー状況を確認しています…", mention_author=False)
         # 状況確認と確認ダイアログを実行する処理
         if not await self._confirm_if_players(ctx):
             await response.edit(content="操作をキャンセルしました")
+            # 操作者がキャンセルした場合も履歴へ残す処理
+            # ステータス履歴に記録するために実行者名を取得する処理
+            actor_label = getattr(ctx.author, "display_name", str(ctx.author))
+            self._manager.register_operation(
+                actor_name=actor_label,
+                summary="再起動操作をキャンセルしました",
+                success=False,
+                occurred_at=datetime.now(timezone.utc),
+            )
             return
         # 実際のサーバー操作を共通関数に委譲する処理
         await self._execute_action(
@@ -237,6 +262,8 @@ class ServerCommandsCog(commands.Cog):
         pending_state: str,
         success_state: str,
     ) -> None:
+        # ステータス履歴へ記録する際に利用する実行者名を抽出する処理
+        actor_label = getattr(ctx.author, "display_name", str(ctx.author))
         try:
             # 現在の状態を確認する処理
             status_before = await self._controller.get_status()
@@ -249,6 +276,13 @@ class ServerCommandsCog(commands.Cog):
                 state_label = self._describe_state(status_before.state)
                 note = f"{action_name}は現在の状態（{state_label}）では実行できません"
                 await message.edit(content=f"サーバーが現在{state_label}のため、{action_name}できません")
+                # 実行不可能だった操作も履歴に記録する処理
+                self._manager.register_operation(
+                    actor_name=actor_label,
+                    summary=note,
+                    success=False,
+                    occurred_at=datetime.now(timezone.utc),
+                )
                 await self._manager.update(status_before.state, status_before.players, note)
                 return
             # 操作開始をチャンネルに知らせる処理
@@ -265,6 +299,13 @@ class ServerCommandsCog(commands.Cog):
             failure_text = f"サーバー{action_name}に失敗しました: {error}"
             await message.edit(content=failure_text)
             status_after = await self._controller.get_status()
+            # 操作失敗を履歴へ記録する処理
+            self._manager.register_operation(
+                actor_name=actor_label,
+                summary=failure_text,
+                success=False,
+                occurred_at=datetime.now(timezone.utc),
+            )
             await self._manager.update(status_after.state, status_after.players, failure_text)
             return
         except Exception as exc:  # pylint: disable=broad-except
@@ -272,6 +313,13 @@ class ServerCommandsCog(commands.Cog):
             failure_text = f"サーバー{action_name}で予期せぬエラが発生しました"
             await message.edit(content=failure_text)
             status_after = await self._controller.get_status()
+            # 予期せぬ失敗を履歴へ記録する処理
+            self._manager.register_operation(
+                actor_name=actor_label,
+                summary=failure_text,
+                success=False,
+                occurred_at=datetime.now(timezone.utc),
+            )
             await self._manager.update(status_after.state, status_after.players, failure_text)
             return
         # 結果に応じてメッセージを整形する処理
@@ -279,6 +327,13 @@ class ServerCommandsCog(commands.Cog):
             await message.edit(content=result.message)
             status_after = await self._controller.get_status()
             final_state = status_after.state if status_after.state != "unknown" else success_state
+            # 操作成功を履歴へ記録する処理
+            self._manager.register_operation(
+                actor_name=actor_label,
+                summary=result.message,
+                success=True,
+                occurred_at=datetime.now(timezone.utc),
+            )
             await self._manager.update(final_state, status_after.players, result.message)
         else:
             detail = f" 詳細: {result.detail}" if result.detail else ""
@@ -290,6 +345,13 @@ class ServerCommandsCog(commands.Cog):
             )
             await message.edit(content=failure_text)
             status_after = await self._controller.get_status()
+            # 操作失敗を履歴へ記録する処理
+            self._manager.register_operation(
+                actor_name=actor_label,
+                summary=failure_text,
+                success=False,
+                occurred_at=datetime.now(timezone.utc),
+            )
             await self._manager.update(status_after.state, status_after.players, failure_text)
 
     # このメソッドは状態コードを日本語の説明文へ変換する

--- a/bot/cogs/status_updater.py
+++ b/bot/cogs/status_updater.py
@@ -96,6 +96,8 @@ class StatusUpdaterCog(commands.Cog):
         # 初期化開始をログに出力する処理
         self._logger.info("状況メッセージの初期化を開始します")
         await self._manager.ensure_message()
+        # チャンネルに残っている旧コマンドメッセージを整理する処理
+        await self._manager.cleanup_command_messages()
         # 状況監視ループを開始する処理（asyncio.create_taskでイベントループ取得を抽象化）
         # 監視ループ開始をログに出力する処理
         self._logger.info("状態監視ループを開始します")

--- a/bot/status_message.py
+++ b/bot/status_message.py
@@ -38,6 +38,14 @@ class StatusMessageManager:
         self._last_state: Optional[str] = stored_data.get("last_known_state")
         # 最後に確認したプレイヤー数を保持する変数
         self._last_player_count: int = stored_data.get("last_player_count", 0)
+        # 直近のサーバー操作を実行した利用者名を保持する変数
+        self._last_operation_actor: Optional[str] = stored_data.get("last_operation_actor")
+        # 直近のサーバー操作の概要文を保持する変数
+        self._last_operation_summary: Optional[str] = stored_data.get("last_operation_summary")
+        # 直近のサーバー操作が成功したかどうかを保持する変数
+        self._last_operation_success: Optional[bool] = stored_data.get("last_operation_success")
+        # 直近のサーバー操作が発生した時刻（ISO8601文字列）を保持する変数
+        self._last_operation_timestamp: Optional[str] = stored_data.get("last_operation_timestamp")
 
     # このメソッドはチャンネル内に状況メッセージが存在するか確認し、なければ作成する
     # 呼び出し元: StatusUpdaterCogのsetup_hookや状態更新処理
@@ -110,6 +118,54 @@ class StatusMessageManager:
         notice_message = await channel.send(content)
         # 後始末として一定時間後に削除する非同期タスクを起動する処理
         asyncio.create_task(self.delete_later(notice_message, delete_after))
+
+    # このメソッドは状況チャンネルから状況メッセージ以外の投稿を削除する
+    # 呼び出し元: bot.cogs.server_commands 内の各コマンド実行前、および起動直後のクリーンアップ処理
+    # 引数: preserve_ids は削除せず保持したいメッセージIDの反復可能オブジェクト
+    # 戻り値: なし
+    async def cleanup_command_messages(self, *, preserve_ids: Optional[Iterable[int]] = None) -> None:
+        # 排他制御のためロックを取得する処理
+        async with self._lock:
+            # チャンネルオブジェクトを取得する処理
+            channel = await self._fetch_channel()
+            if channel is None:
+                return
+            # 保存対象メッセージIDを集合に変換する処理
+            preserved: set[int] = set(preserve_ids or [])
+            # ステータスメッセージ自身は常に保持対象に加える処理
+            if self._message_id is not None:
+                preserved.add(self._message_id)
+            # チャンネル内の履歴を走査し、不要なメッセージを削除する処理
+            async for message in channel.history(limit=None):
+                if message.id in preserved:
+                    continue
+                try:
+                    await message.delete()
+                except discord.HTTPException:
+                    # 権限不足や既に削除済みの場合は無視する処理
+                    continue
+
+    # このメソッドは直近のサーバー操作情報を記録する
+    # 呼び出し元: bot.cogs.server_commands 内の操作実行処理
+    # 引数: actor_name は実行者名、summary は操作概要、success は成功可否、occurred_at は発生時刻（未指定時は現在時刻）
+    # 戻り値: なし
+    def register_operation(
+        self,
+        *,
+        actor_name: str,
+        summary: str,
+        success: bool,
+        occurred_at: Optional[datetime] = None,
+    ) -> None:
+        # 実行者名を保持する処理
+        self._last_operation_actor = actor_name
+        # 操作概要文を保持する処理
+        self._last_operation_summary = summary
+        # 操作結果の成否を保持する処理
+        self._last_operation_success = success
+        # 発生時刻をISO8601文字列として保持する処理
+        timestamp = occurred_at or datetime.now(timezone.utc)
+        self._last_operation_timestamp = timestamp.isoformat()
 
     # このメソッドはチャンネルオブジェクトを取得する
     # 呼び出し元: ensure_message, update
@@ -257,7 +313,45 @@ class StatusMessageManager:
         else:
             # 補足情報がない場合でもEmbedでオンライン人数とプレイヤー名を確認できる旨を記載する処理
             summary += "\nℹ️ Embedタイトルと内容でオンライン状況を確認できます"
+        # 直近操作情報を追記する処理
+        history_line = self._build_last_operation_line()
+        if history_line:
+            summary += f"\n📅 {history_line}"
         return summary
+
+    # このメソッドは最後に実行されたサーバー操作の概要文を構築する
+    # 呼び出し元: _build_text_summary
+    # 引数: なし
+    # 戻り値: 直近操作情報のテキスト（存在しない場合は空文字列）
+    def _build_last_operation_line(self) -> str:
+        # 操作概要が未設定の場合は空文字列を返す処理
+        if not self._last_operation_summary or not self._last_operation_timestamp:
+            return ""
+        # 操作時刻をユーザー向け表示に整形する処理
+        try:
+            occurred_at = datetime.fromisoformat(self._last_operation_timestamp)
+        except ValueError:
+            occurred_at = None
+        if occurred_at is not None and occurred_at.tzinfo is None:
+            # タイムゾーン情報が欠落している場合はUTC扱いで補完する処理
+            occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+        # ローカルタイムゾーン情報を取得する処理
+        local_zone = datetime.now().astimezone().tzinfo
+        # 表示用にローカルタイムゾーンへ変換する処理
+        display_time = occurred_at.astimezone(local_zone) if occurred_at and local_zone else occurred_at
+        # 表示用の時刻文字列を決定する処理
+        time_text = display_time.strftime("%Y-%m-%d %H:%M:%S %Z") if display_time else "時刻不明"
+        # 成否に応じた絵文字を選択する処理（成功可否が不明な場合は疑問符を表示）
+        if self._last_operation_success is True:
+            status_icon = "✅"
+        elif self._last_operation_success is False:
+            status_icon = "❌"
+        else:
+            status_icon = "❔"
+        # 実行者名を利用する処理（未設定の場合は"不明"を表示）
+        actor = self._last_operation_actor or "不明"
+        # まとめた文字列を返す処理
+        return f"{status_icon} {time_text} / {actor} / {self._last_operation_summary}"
 
     # このメソッドは状態に応じた表示情報を返す
     # 呼び出し元: _compose_visuals
@@ -289,6 +383,10 @@ class StatusMessageManager:
                 "status_message_id": self._message_id,
                 "last_known_state": state,
                 "last_player_count": player_count,
+                "last_operation_actor": self._last_operation_actor,
+                "last_operation_summary": self._last_operation_summary,
+                "last_operation_success": self._last_operation_success,
+                "last_operation_timestamp": self._last_operation_timestamp,
             }
         )
         self._last_state = state


### PR DESCRIPTION
## 概要
- サーバー状況チャンネルからコマンド履歴を削除するクリーンアップ処理を追加
- サーバー操作の実行者・結果・時刻を状況メッセージへ追記できるよう履歴情報を永続化
- Bot起動時および各操作前に履歴整理を実施し、最後の操作がわかるようメッセージを拡張

## テスト
- python -m compileall bot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136aba5ab48324a9b455205d005bf8)