### PR TITLE
Portainer向けComposeとREADMEをリポジトリURL指定で動かしやすく調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,18 @@
 
 ## Portainer（Git Repository Stack）でのデプロイ手順
 
+### 0) このリポジトリURLをPortainerに渡して「そのまま」実行できるか
+- **結論:** ほぼそのまま実行できます。
+- ただし、秘密情報を含む `config.ini` はGit管理しないため、**ホスト側で `/opt/showmc/config.ini` を事前作成**する必要があります。
+- パスを変えたい場合は、Portainerの環境変数で `SHOWMC_CONFIG_PATH` を指定してください。
+
 ### 1) Stack作成時にGitリポジトリとComposeパスを指定
-1. Portainerで **Stacks** → **Add stack** を開きます。
-2. **Build method** で **Git Repository** を選択します。
-3. **Repository URL** に本リポジトリURLを設定します。
-4. **Compose path** に `docker-compose.yml` を指定します。
-5. 必要に応じてブランチを選択し、デプロイを実行します。
+- [ ] Portainerで **Stacks** → **Add stack** を開く
+- [ ] **Build method** で **Git Repository** を選択する
+- [ ] **Repository URL** に本リポジトリURLを設定する
+- [ ] **Compose path** に `docker-compose.portainer.yml` を指定する
+- [ ] （任意）`SHOWMC_CONFIG_PATH` を設定する（未指定時は `/opt/showmc/config.ini`）
+- [ ] 必要に応じてブランチを選択してデプロイする
 
 ### 2) ホスト側に `config.ini` を作成（Gitに秘密情報を置かない）
 1. ホスト上で設定ディレクトリを作成します。
@@ -91,15 +97,26 @@
 
 > **重要:** `config.ini` にはDiscordトークン等の秘密情報が入るため、Gitへコミットせずホスト側で管理してください。
 
-### 3) `/mc` 制御の推奨設定
+### 3) `/mc` 制御の必須・推奨設定
+- `/mc` のdocker制御を使うため、`/var/run/docker.sock` のマウントは**必須**です。
 - 初期運用は `container` モードを推奨します。
   - `MC_CONTROL_MODE=docker`
   - `MC_MODE=container`
-  - `MC_CONTAINER_NAME` にPortainer上で確認できるMinecraftコンテナ名を設定
+  - `MC_CONTAINER_NAME` に既存Minecraftコンテナ名を設定
 - セキュリティ上、`MC_ALLOWED_USER_IDS` または `MC_ALLOWED_ROLE_IDS` は**必ず設定**してください。
 
-### 4) 障害時の確認
-- Botの例外と失敗理由はログへ出力されるため、Portainerのコンテナログ（または `docker logs`）を確認してください。
+### 4) composeモードを使う場合の追加設定
+- `MC_MODE=compose` を使う場合は、`docker-compose.portainer.yml` の次行コメントを外してマウントを有効化してください。
+  - `- ${MC_STACK_PATH:-/opt/minecraft-stack}:/opt/minecraft-stack:ro`
+- あわせて `config.ini` 側の `MC_PROJECT_DIR` / `MC_COMPOSE_FILE` が、そのマウント内のパスと一致することを確認してください。
+
+### 5) 障害時の確認
+- 失敗時はDiscordのエラーチャンネルへ理由を通知し、標準エラー出力の要点もログに残します。
+- Portainerのコンテナログ（または `docker logs`）で、直近の例外とstderr要点を確認してください。
+
+### 6) 既存Composeファイルの扱い
+- `docker-compose.yml` と `docker-compose.bot.yml` は改行入りの有効なYAMLです。
+- PortainerでGit Repository Stackとして使う場合は、`docker-compose.portainer.yml` の利用を推奨します。
 
 ---
 

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -1,0 +1,19 @@
+# PortainerのGit Repository Stackから直接デプロイするための専用Compose定義
+services:
+  show-minecraft-player-bot:
+    # リポジトリ直下のDockerfileを使ってPortainer側でビルドする
+    build: .
+    # Botがconfig.iniを相対参照できるよう作業ディレクトリを固定する
+    working_dir: /app
+    # エントリポイントは明示的にモジュール実行で固定する
+    command: ["python", "-m", "bot.main"]
+    volumes:
+      # /mc のDocker制御で必須となるdocker.sockをマウントする
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      # ホスト側で管理する機密情報入り設定ファイルを読み取り専用で渡す
+      # 環境変数 SHOWMC_CONFIG_PATH が未指定なら /opt/showmc/config.ini を利用する
+      - ${SHOWMC_CONFIG_PATH:-/opt/showmc/config.ini}:/app/config.ini:ro
+      # composeモードを使う場合のみ、必要に応じて次行のコメントを外して利用する
+      # - ${MC_STACK_PATH:-/opt/minecraft-stack}:/opt/minecraft-stack:ro
+    # 常時運用を想定して手動停止まで自動再起動する
+    restart: unless-stopped


### PR DESCRIPTION
### Motivation
- Portainerの「Git Repository Stack」でリポジトリURLを渡しただけで動かせるように初回導入の詰まりどころを減らすためです。 
- `config.ini` 等の秘密情報はGitに置かない前提のまま、パス差異を吸収してデプロイ手順を明確化する必要がありました。

### Description
- 新規ファイル `docker-compose.portainer.yml` を追加し、`show-minecraft-player-bot` サービスは `build: .`、`working_dir: /app`、`command: ["python","-m","bot.main"]`、`/var/run/docker.sock` マウントと `SHOWMC_CONFIG_PATH` 環境変数で上書き可能な `config.ini` マウント（デフォルト `/opt/showmc/config.ini`）を定義しました、`/opt/minecraft-stack` マウントはコメント化して初期運用を簡素化しています。 
- `README.md` の Portainer セクションを再構成し、リポジトリURLを渡して「ほぼそのまま」動く旨の結論、ホスト側での `config.ini` 作成手順、`SHOWMC_CONFIG_PATH` の使い方、`container` と `compose` モードの切り分け、チェックリスト形式のStack作成手順、障害時の確認方法を追記しました。 
- 既存の `docker-compose.yml` / `docker-compose.bot.yml` の有効性は維持し、Portainerでの利用時には `docker-compose.portainer.yml` を推奨する旨を明記しました。

### Testing
- `python -m compileall bot` を実行してPythonコードのバイトコード生成チェックは成功しました。 
- `pyyaml` をインストールして `yaml.safe_load(...)` により `docker-compose.yml`、`docker-compose.bot.yml`、`docker-compose.portainer.yml` のパース検証を行い、全ファイルに `services` キーが存在することを確認しました。 
- `docker compose -f docker-compose.portainer.yml config` によるComposeのローカル検証は実行環境に `docker` コマンドがなかったため未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ae40dbb708324b66da436ebbf08dd)