### PR TITLE
起動時のDiscordアプリケーションID未設定エラーを防ぐ初期化順序の修正

### DIFF
--- a/bot/cogs/status_updater.py
+++ b/bot/cogs/status_updater.py
@@ -100,7 +100,14 @@ class StatusUpdaterCog(commands.Cog):
     async def _initialize_after_ready(self) -> None:
         # Botのログイン完了を待機する処理
         self._logger.info("Botの準備完了を待機しています")
-        await self._bot.wait_until_ready()
+        # login前にwait_until_readyを呼ぶと例外化するため、初期化完了までリトライ待機する処理
+        while True:
+            try:
+                await self._bot.wait_until_ready()
+                break
+            except RuntimeError:
+                # discord.pyの内部初期化が終わるまで短時間待機して再試行する処理
+                await asyncio.sleep(1)
         # 状況メッセージの存在を確保する処理
         self._logger.info("状況メッセージの初期化を開始します")
         await self._manager.ensure_message()

--- a/bot/main.py
+++ b/bot/main.py
@@ -31,6 +31,33 @@ from .utils.console_status import console_status_display
 _LOGGING_LISTENER: Optional[QueueListener] = None
 
 
+class ShowMinecraftPlayerBot(commands.Bot):
+    """アプリケーションコマンド同期タイミングを制御するBot実装"""
+
+    # このコンストラクタはBot生成時に同期方針フラグを初期化する
+    # 呼び出し元: main 関数のBot初期化処理
+    # 引数: args/kwargs は commands.Bot の初期化引数
+    # 戻り値: なし
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        # 親クラスの初期化処理を実行してdiscord.pyの内部状態を構築する処理
+        super().__init__(*args, **kwargs)
+        # スラッシュコマンド同期を1回だけ実行するためのフラグを保持する変数
+        self._is_tree_synced = False
+
+    # このメソッドはログイン後に呼ばれ、アプリケーションID確定後にコマンド同期を行う
+    # 呼び出し元: discord.py の setup_hook ライフサイクル
+    # 引数: なし
+    # 戻り値: なし
+    async def setup_hook(self) -> None:
+        # 既に同期済みなら重複実行を避ける処理
+        if self._is_tree_synced:
+            return
+        # Discordへアプリケーションコマンドを同期する処理
+        await self.tree.sync()
+        # 同期完了フラグを更新する処理
+        self._is_tree_synced = True
+
+
 # この関数はイベントループをブロックしないログ設定を適用する
 # 呼び出し元: main 関数の設定読み込み後
 # 引数: level_name は設定ファイルで指定されたログレベル名
@@ -77,7 +104,7 @@ async def main() -> None:
     intents = discord.Intents.default()
     intents.message_content = True
     # Botインスタンスを生成する処理（!プレフィックスのテキストコマンドを利用）
-    bot = commands.Bot(command_prefix="!", intents=intents)
+    bot = ShowMinecraftPlayerBot(command_prefix="!", intents=intents)
 
     # このローカル関数はID一覧設定文字列を整数リストへ変換する
     # 呼び出し元: main 関数内の /mc コマンド設定読み込み処理
@@ -150,8 +177,6 @@ async def main() -> None:
             parse_id_list(config.minecraft_control.mc_allowed_role_ids),
         )
     )
-    # スラッシュコマンド定義をDiscordへ同期する処理
-    await bot.tree.sync()
     # Botを起動する処理
     await bot.start(config.discord.token)
 


### PR DESCRIPTION
### Motivation
- 起動ログにある `discord.errors.MissingApplicationID` を回避するため、アプリケーションコマンド同期のタイミングをアプリケーションID確定後に移動する必要があった。 
- Cog の初期化処理が早すぎて `wait_until_ready()` 呼び出しで `RuntimeError` が発生していたため、初期化待機の堅牢性を向上させる必要があった。

### Description
- `bot/main.py` に `ShowMinecraftPlayerBot`（`commands.Bot` 継承）を追加し、`setup_hook` 内で `await self.tree.sync()` を実行するようにして同期タイミングをログイン後に移動しました。 
- `main()` 内での直接的な `await bot.tree.sync()` 呼び出しを削除して、アプリケーションID未設定による同期失敗を防止しました。 
- `bot/cogs/status_updater.py` の `_initialize_after_ready` を修正し、`wait_until_ready()` が `RuntimeError` を投げる場合は短時間待機してリトライするループを導入して初期化完了まで待つようにしました。 
- 変更対象ファイルは `bot/main.py` と `bot/cogs/status_updater.py` です。すべての新規／変更箇所には日本語コメントを追加しています。 

### Testing
- `python -m compileall bot` を実行してソースのコンパイルチェックを行い、構文エラーがないことを確認しました（成功）。
- 変更はモジュール単位でインポート可能であることを確認するためにファイルをコンパイルしました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b29beec6c8324bb72b3c8668d8cd3)